### PR TITLE
Merge deployment tests into development

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
   "projects": {
-    "default": "rocketry-minerva"
+    "default": "rocketry-minerva",
+    "development": "rocketry-minerva-dev"
   }
 }

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,6 @@
 {
   "projects": {
-    "default": "rocketry-minerva",
-    "development": "rocketry-minerva-dev"
+    "default": "rocketry-minerva-dev",
+    "production": "rocketry-minerva"
   }
 }

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -19,12 +19,10 @@ jobs:
         node-version: 12.x
     - run: npm install
       working-directory: ../minerva/functions/
-    - run: npm test
-      working-directory: ../minerva/functions/
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
     - name: Deploy to Firebase
-      uses: chrissank/deploy-firebase-functions@1.0.4
+      uses: chrissank/deploy-firebase-functions@1.1.0
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         TARGET: development

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -2,9 +2,7 @@ name: Deploy to Firebase
 
 on:
   push:
-    branches:
-      - '**'
-      - '!master'
+    branches: [master]
 
 jobs:
   main:

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -22,7 +22,7 @@ jobs:
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
     - name: Deploy to Firebase
-      uses: chrissank/deploy-firebase-functions@1.0.2
+      uses: chrissank/deploy-firebase-functions@1.0.4
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         TARGET: development

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -21,7 +21,8 @@ jobs:
       working-directory: ../minerva/functions/
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
-    - run: firebase use --token ${{ secrets.FIREBASE_TOKEN }} development
-      working-directory: ../minerva/
-    - run: firebase deploy --only functions
-      working-directory: ../minerva/
+    - name: Deploy to Firebase
+      uses: chrissank/deploy-firebase-functions@1.0.2
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        TARGET: development

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -2,7 +2,9 @@ name: Deploy to Firebase
 
 on:
   push:
-    branches: [master]
+    branches:
+      - '**'
+      - '!master'
 
 jobs:
   main:

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -25,4 +25,4 @@ jobs:
       uses: chrissank/deploy-firebase-functions@1.1.0
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        TARGET: development
+        TARGET: default

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -2,7 +2,7 @@ name: Deploy to Firebase
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, deployment-test ]
 
 jobs:
   main:
@@ -22,6 +22,7 @@ jobs:
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
     - name: Deploy to Firebase
-      uses: BIGG-Kaymo/deploy-firebase-functions@v1.0.1
+      uses: chrissank/deploy-firebase-functions@1.0.0
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        TARGET: development

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -2,9 +2,7 @@ name: Deploy to Firebase
 
 on:
   push:
-    branches:
-      - '**'
-      - '!master'
+    branches: [master]
 
 jobs:
   main:

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -22,7 +22,7 @@ jobs:
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
     - name: Deploy to Firebase
-      uses: chrissank/deploy-firebase-functions@1.0.1
+      uses: chrissank/deploy-firebase-functions@v1.0.1
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         TARGET: development

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -23,4 +23,4 @@ jobs:
       uses: chrissank/deploy-firebase-functions@1.1.0
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        TARGET: default
+        TARGET: production

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -22,7 +22,7 @@ jobs:
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
     - name: Deploy to Firebase
-      uses: chrissank/deploy-firebase-functions@1.0.0
+      uses: chrissank/deploy-firebase-functions@1.0.1
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         TARGET: development

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -17,12 +17,10 @@ jobs:
         node-version: 12.x
     - run: npm install
       working-directory: ../minerva/functions/
-    - run: npm test
-      working-directory: ../minerva/functions/
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
     - name: Deploy to Firebase
-      uses: chrissank/deploy-firebase-functions@1.0.2
+      uses: chrissank/deploy-firebase-functions@1.1.0
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        TARGET: development
+        TARGET: default

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -23,7 +23,8 @@ jobs:
       working-directory: ../minerva/functions/
     - run: npm run build --if-present
       working-directory: ../minerva/functions/
-    - run: firebase use --token ${{ secrets.FIREBASE_TOKEN }} development
-      working-directory: ../minerva/
-    - run: firebase deploy --only functions
-      working-directory: ../minerva/
+    - name: Deploy to Firebase
+      uses: chrissank/deploy-firebase-functions@1.0.2
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        TARGET: development


### PR DESCRIPTION
Pushing to a non-master branch will automatically deploy to `rocketry-minerva-dev` firebase project, which is tied to `minerva-dev` slackbot which is on the development slack.

Merging into master will automatically deploy to `rocketry-minerva`, which is tied to `minerva` slackbot (on the main slack). This way, things remain separate, and people can develop features without hurting the production slackbot.