### PR TITLE
Modify if condition for seedMessageReactions

### DIFF
--- a/functions/scheduled/events.js
+++ b/functions/scheduled/events.js
@@ -54,7 +54,7 @@ module.exports.checkForEvents = async function () {
                 }
             }
 
-            if (emojiPair.length) {
+            if (emojiPair !== undefined) {
                 for (let response of messageResponses) {
                     await this.seedMessageReactions(response.channel, emojiPair, response.ts);
                 }


### PR DESCRIPTION
Modified the `if` condition that iterates through the message responses and seeds them with emojis. Previously, to check if the messages needed seeding, the condition was checking if the `emojiPair` array had a length property that's not zero, which would only exist if the array was initialized properly and had elements in it. When `emojiPair` is not needed (i.e. a 5-minute warning reminder is being generated that doesn't require reactions), the `generateMessage` function initializes the variable to `undefined`, which has no length property, and thus would throw an error.

While this doesn't seem to cause any issues with the operation of the function, it does throw a `TypeError`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva/17)
<!-- Reviewable:end -->
