### PR TITLE
Make edit default

### DIFF
--- a/__tests__/unit/edit.meeting.test.js
+++ b/__tests__/unit/edit.meeting.test.js
@@ -15,7 +15,7 @@ describe("commands/meeting/edit.js tests", function () {
                         id: "123456789",
                         summary: "F20 Weekly Meetings",
                         start: {
-                            dateTime: new Date(2020, 10, 6, 3, 33),
+                            dateTime: new Date('November 06 2020 3:33 EST'),
                         },
                     },
                     {

--- a/src/commands/meeting.js
+++ b/src/commands/meeting.js
@@ -2,7 +2,9 @@ module.exports.send = async function (userId, textParams, originChannelID, origi
     if (textParams.startsWith("reminder")) {
         return require("./meeting/reminder").send(originChannelID);
     // the "edit" path is the default if no textParam is provided
-    } else {
+    } else if (textParams.startsWith("edit") || textParams.trim().length === 0){
         return require("./meeting/edit").send(originChannelID, trigger);
-    } 
+    } else {
+        return Promise.reject("Incorrect usage: /meeting <reminder/edit>");
+    }
 };

--- a/src/commands/meeting.js
+++ b/src/commands/meeting.js
@@ -1,9 +1,8 @@
 module.exports.send = async function (userId, textParams, originChannelID, originChannelName, trigger) {
     if (textParams.startsWith("reminder")) {
         return require("./meeting/reminder").send(originChannelID);
-    } else if (textParams.startsWith("edit")) {
-        return require("./meeting/edit").send(originChannelID, trigger);
+    // the "edit" path is the default if no textParam is provided
     } else {
-        return Promise.reject("Incorrect usage: /meeting <reminder/edit>");
-    }
+        return require("./meeting/edit").send(originChannelID, trigger);
+    } 
 };

--- a/src/commands/meeting/edit.js
+++ b/src/commands/meeting/edit.js
@@ -79,7 +79,7 @@ module.exports.parseMeetingBlock = async function (event, parameters) {
     meetingBlock.private_metadata = JSON.stringify(metadata);
 
     meetingBlock.blocks[0].text.text =
-        "Editing meeting: *" + event.summary + "* occuring on *" + moment(event.start.dateTime).tz(moment.tz.guess()).format("MMMM Do, YYYY [at] h:mm A") + "*";
+        "Editing meeting: *" + event.summary + "* occuring on *" + moment(event.start.dateTime).tz("America/Toronto").format("MMMM Do, YYYY [at] h:mm A") + "*";
 
     meetingBlock.blocks[2].element.initial_value = parameters.location;
     meetingBlock.blocks[4].element.initial_value = parameters.link;

--- a/src/commands/meeting/edit.js
+++ b/src/commands/meeting/edit.js
@@ -79,7 +79,7 @@ module.exports.parseMeetingBlock = async function (event, parameters) {
     meetingBlock.private_metadata = JSON.stringify(metadata);
 
     meetingBlock.blocks[0].text.text =
-        "Editing meeting: *" + event.summary + "* occuring on *" + moment(event.start.dateTime).tz("America/Toronto").format("MMMM Do, YYYY [at] h:mm A") + "*";
+        "Editing meeting: *" + event.summary + "* occuring on *" + moment(event.start.dateTime).tz(moment.tz.guess()).format("MMMM Do, YYYY [at] h:mm A") + "*";
 
     meetingBlock.blocks[2].element.initial_value = parameters.location;
     meetingBlock.blocks[4].element.initial_value = parameters.link;


### PR DESCRIPTION
Makes the `meeting` command default to `edit` if no option is specified, instead of throwing an error.
Also changes the time zone detection to be automatic, instead of being hardcoded as Toronto.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva/29)
<!-- Reviewable:end -->
