### PR TITLE
Fix emoji seeding race condition for meeting messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,11 @@ exports.slack_commands_sync = async (event, context) => {
 
     let url;
     if (context.invokedFunctionArn.split(":")[7] !== "production") {
-        url = "https://rh9ew5a2rd.execute-api.us-east-1.amazonaws.com/development/minerva-slackCommandsAsync-23U2OZVQ02AT";
+        console.log("Sending to minerva slackCommandsAsync development...");
+        url = "https://g34h315ctk.execute-api.us-east-1.amazonaws.com/development/minerva-slackCommandsAsync-rzdj53m68JE9";
     } else {
-        url = "https://obs7kx9u7g.execute-api.us-east-1.amazonaws.com/production/minerva-slackCommandsAsync-23U2OZVQ02AT";
+        console.log("Sending to minerva slackCommandsAsync production...");
+        url = "https://bbfl9ivf5k.execute-api.us-east-1.amazonaws.com/production/minerva-slackCommandsAsync-rzdj53m68JE9";
     }
 
     await new Promise((resolve, reject) => {
@@ -119,9 +121,11 @@ exports.interactivity_sync = async (event, context) => {
 
     let url;
     if (context.invokedFunctionArn.split(":")[7] !== "production") {
-        url = "https://ez4h5h0yki.execute-api.us-east-1.amazonaws.com/development/minerva-interactivityAsync-HNTIX0A0L940";
+        console.log("Sending to minerva interactivityAsync development...");
+        url = "https://g4jwnsqon1.execute-api.us-east-1.amazonaws.com/development/minerva-interactivityAsync-E6D7tlk3NjwP";
     } else {
-        url = "https://edmqut7avb.execute-api.us-east-1.amazonaws.com/production/minerva-interactivityAsync-HNTIX0A0L940";
+        console.log("Sending to minerva interactivityAsync production...");
+        url = "https://9vkjfez4a3.execute-api.us-east-1.amazonaws.com/production/minerva-interactivityAsync-E6D7tlk3NjwP";
     }
 
     await new Promise((resolve, reject) => {

--- a/src/scheduled/events.js
+++ b/src/scheduled/events.js
@@ -160,6 +160,8 @@ module.exports.generateEmojiPair = async function () {
 module.exports.seedMessageReactions = async function (channel, emojis, timestamp) {
     let response = await slack_handler.addReactionToMessage(channel, emojis[0], timestamp);
     if (response.ok) {
-        await slack_handler.addReactionToMessage(channel, emojis[1], timestamp);
+        setTimeout(async () => {
+            await slack_handler.addReactionToMessage(channel, emojis[1], timestamp);
+        }, 1000)
     }
 };

--- a/src/scheduled/events.js
+++ b/src/scheduled/events.js
@@ -158,6 +158,8 @@ module.exports.generateEmojiPair = async function () {
 };
 
 module.exports.seedMessageReactions = async function (channel, emojis, timestamp) {
-    await slack_handler.addReactionToMessage(channel, emojis[0], timestamp);
-    await slack_handler.addReactionToMessage(channel, emojis[1], timestamp);
+    let response = await slack_handler.addReactionToMessage(channel, emojis[0], timestamp);
+    if (response.ok) {
+        await slack_handler.addReactionToMessage(channel, emojis[1], timestamp);
+    }
 };


### PR DESCRIPTION
Fixed an issue where the "seed" emojis added by Minerva to meeting messages will be in the wrong order due to a race condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva/45)
<!-- Reviewable:end -->
