### PR TITLE
Change references of chrisslackbottesting to waterloorocketrydev

### DIFF
--- a/__tests__/jest.setup.js
+++ b/__tests__/jest.setup.js
@@ -6,6 +6,6 @@ jest.mock("../src/handlers/environment-handler", () => {
         googleSecret: "test",
         googleRedirect: "test",
         googleToken: "test",
-        slackUrl: "https://chrisslackbottesting.slack.com"
+        slackUrl: "https://waterloorocketrydev.slack.com"
     };
 });

--- a/__tests__/unit/notify.test.js
+++ b/__tests__/unit/notify.test.js
@@ -28,7 +28,7 @@ describe("commands/notify.js tests", function () {
         });
         it("good notify block", async function () {
             assert.deepStrictEqual(await notify.extractNotifyParameters(require("./notifyBlocks/goodNotifyResult.json")), {
-                link: "https://chrisslackbottesting.slack.com/archives/C07MXA613/p1605073692312300",
+                link: "https://waterloorocketrydev.slack.com/archives/C07MXA613/p1605073692312300",
                 alertType: "alert",
                 channels: ["C01535M46SC", "C8VL7QCG0", "CCWGTJH7F", "C4H4NJG77", "C07MWEYPR", "C07MX0QDS", "C90E34QDD", "CV7S1E49Y", "C07MX5JDB"],
             });

--- a/__tests__/unit/notifyBlocks/goodNotifyResult.json
+++ b/__tests__/unit/notifyBlocks/goodNotifyResult.json
@@ -50,7 +50,7 @@
             "link": {
                 "link": {
                     "type": "plain_text_input",
-                    "value": "https://chrisslackbottesting.slack.com/archives/C07MXA613/p1605073692312300"
+                    "value": "https://waterloorocketrydev.slack.com/archives/C07MXA613/p1605073692312300"
                 }
             }
         }

--- a/__tests__/unit/notifyBlocks/noAlertBlockResult.json
+++ b/__tests__/unit/notifyBlocks/noAlertBlockResult.json
@@ -43,7 +43,7 @@
             "link": {
                 "link": {
                     "type": "plain_text_input",
-                    "value": "https://chrisslackbottesting.slack.com/archives/C07MXA613/p1605073692312300"
+                    "value": "https://waterloorocketrydev.slack.com/archives/C07MXA613/p1605073692312300"
                 }
             }
         }

--- a/__tests__/unit/notifyBlocks/noChannelsBlockResult.json
+++ b/__tests__/unit/notifyBlocks/noChannelsBlockResult.json
@@ -50,7 +50,7 @@
             "link": {
                 "link": {
                     "type": "plain_text_input",
-                    "value": "https://chrisslackbottesting.slack.com/archives/C07MXA613/p1605073692312300"
+                    "value": "https://waterloorocketrydev.slack.com/archives/C07MXA613/p1605073692312300"
                 }
             }
         }

--- a/src/handlers/environment-handler.js
+++ b/src/handlers/environment-handler.js
@@ -4,4 +4,4 @@ module.exports.googleClient = process.env.googleaccount_client;
 module.exports.googleSecret = process.env.googleaccount_secret;
 module.exports.googleRedirect = process.env.googleaccount_redirect;
 module.exports.googleToken = process.env.googleaccount_token;
-module.exports.slackUrl =  process.env.NODE_ENV == "production" ? "https://waterloorocketry.slack.com" : "https://chrisslackbottesting.slack.com";
+module.exports.slackUrl =  process.env.NODE_ENV == "production" ? "https://waterloorocketry.slack.com" : "https://waterloorocketrydev.slack.com";


### PR DESCRIPTION
Following the change of the Dev Slack workspace's name from `chrisslackbottesting.slack.com` to `waterloorocketrydev.slack.com`, all references in the code have also been changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva/69)
<!-- Reviewable:end -->
