### PR TITLE
remove KMS encryption key for environmental variables

### DIFF
--- a/infra/minerva.js
+++ b/infra/minerva.js
@@ -10,7 +10,6 @@ new MinervaStack(app, "minerva-dev", {
   stackName: "minerva-dev",
   description: "Development Serverless Deployment for Minerva",
   deployEnv: "development",
-  kmsKeyArn: "arn:aws:kms:us-east-1:529410955324:key/f76dd689-2aad-41ba-b56a-2166a43f9576",
   env: { account: '529410955324', region: 'us-east-1'}
 });
 
@@ -19,6 +18,5 @@ new MinervaStack(app, 'minerva-prod', {
   stackName: "minerva-prod",
   description: "Production Serverless Deployment for Minerva",
   deployEnv: "production",
-  kmsKeyArn: "arn:aws:kms:us-east-2:529410955324:key/47198e8d-b801-4ac1-a871-53b6a3a3f6dd",
   env: { account: '529410955324', region: 'us-east-2'},
 });

--- a/infra/minervaStack.js
+++ b/infra/minervaStack.js
@@ -5,7 +5,6 @@ const logs = require( 'aws-cdk-lib/aws-logs' );
 const lambda = require( 'aws-cdk-lib/aws-lambda' );
 const awsEvents = require( 'aws-cdk-lib/aws-events' );
 const awsEventsTargets = require( 'aws-cdk-lib/aws-events-targets' );
-const kms = require( 'aws-cdk-lib/aws-kms' );
 const { NodejsFunction } = require('aws-cdk-lib/aws-lambda-nodejs');
 
 const path = require('path');
@@ -20,7 +19,7 @@ class MinervaStack extends cdk.Stack {
     constructor ( scope, id, props ) {
         super( scope, id, props );
 
-        const { deployEnv, kmsKeyArn } = props
+        const { deployEnv } = props
 
         // Default configuration for Lambda functions
         const lambdaFnProps = {
@@ -37,7 +36,6 @@ class MinervaStack extends cdk.Stack {
                 googleaccount_secret: process.env.googleaccount_secret,
                 googleaccount_token: process.env.googleaccount_token,
             },
-            environmentEncryption: kms.Key.fromKeyArn( this, 'KMSKey', kmsKeyArn ),
             bundling: {
                 target: 'es2020',
                 minify: false,


### PR DESCRIPTION
The AWS Key Management Service keys that we're using encrypt the environmental variables that we're using for our Lambda functions have significantly increased our AWS bill costs. 

This PR will get rid of them at the cost of once again allowing anyone with access to the AWS console to view the Google API and Slack secrets that we're using for Minerva.

**TODO For post-merge**
- Delete the AWS KMS keys from the AWS Console.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva/80)
<!-- Reviewable:end -->
