### PR TITLE
Bump AWS Lambda Function Node Version to v18

### DIFF
--- a/infra/minervaStack.js
+++ b/infra/minervaStack.js
@@ -23,7 +23,7 @@ class MinervaStack extends cdk.Stack {
 
         // Default configuration for Lambda functions
         const lambdaFnProps = {
-            runtime: lambda.Runtime.NODEJS_16_X,
+            runtime: lambda.Runtime.NODEJS_18_X,
             timeout: cdk.Duration.seconds( 100 ),
             memorySize: 128,
             entry: path.join(__dirname, '../src/index.js'),

--- a/infra/minervaStack.js
+++ b/infra/minervaStack.js
@@ -25,7 +25,7 @@ class MinervaStack extends cdk.Stack {
         const lambdaFnProps = {
             runtime: lambda.Runtime.NODEJS_18_X,
             timeout: cdk.Duration.seconds( 100 ),
-            memorySize: 128,
+            memorySize: 256,
             entry: path.join(__dirname, '../src/index.js'),
             logRetention: logs.RetentionDays.ONE_MONTH,
             environment: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6199,6 +6199,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }


### PR DESCRIPTION
Since node v16 has reached EoL and the deploy script is complaining about it, bumped the version of Node that the AWS Lambda functions are using to v18.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/minerva/85)
<!-- Reviewable:end -->
